### PR TITLE
fixed crash when using android < 5.0

### DIFF
--- a/src/android/PDFPrinter.java
+++ b/src/android/PDFPrinter.java
@@ -23,7 +23,11 @@ public class PDFPrinter extends PrintDocumentAdapter {
     private WebView webView = null;
 
     public PDFPrinter(WebView webView, String fileName) {
-        this.mWrappedInstance = webView.createPrintDocumentAdapter(fileName);
+        if(Build.VERSION.SDK_INT >= 21 ){
+            this.mWrappedInstance = webView.createPrintDocumentAdapter(fileName);    
+        } else {
+            this.mWrappedInstance = webView.createPrintDocumentAdapter();    
+        }
         this.webView = webView;
     }
 


### PR DESCRIPTION
The method **createPrintDocumentAdapter(String)** was added in api level 21 (Android 5.0) so the plugin kept crashing when using a lower version of Android.
Sadly I could not find a way to set the filename when using Android 4.4.4 or lower.