### PR TITLE
PDF print to base64 complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The iOS HTML to PDF transformation is based in this work [BNHtmlPdfKit](https://
 
 - Generates a PDF document using a URL or HTML.
 - Open-with menu, open the context menu and (push to cloud, print, save, mail, etc...).  
-- Return the Base64 file representation back, so you can upload the file to a server (IOS only).
+- Return the Base64 file representation back, so you can upload the file to a server (IOS & Android only).
 
 
 ## Supported Platforms
@@ -163,7 +163,12 @@ Due to the different way each platform generates the PDF, options not supported 
     - *share* opens IOS menu with all options available, this came handy when you want IOS take ownership of the generated document..
 
 - Android
-  - fileName: saved file name
+  - documentSize: parameter is ignored but required.
+  - landscape: parameter is ignored but required.
+  - type: 
+    - *base64* give you the pdf in Base64 format.
+    - *share* opens Android native PDF viewer.
+  - fileName : saved file name
 
 - failure callback: receive error information about what going wrong, for now is just raw exception so i need to improve this.
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,7 @@
         <source-file src="src/android/PDFGenerator.java" target-dir="src/com/pdf/generator/"/>
         <source-file src="src/android/PDFPrinter.java" target-dir="src/com/pdf/generator/"/>
         <source-file src="src/android/PDFPrinterWebView.java" target-dir="src/com/pdf/generator/"/>
+        <source-file src="src/android/PDFtoBase64.java" target-dir="src/com/pdf/generator/"/>
 
     </platform>
 

--- a/src/android/PDFGenerator.java
+++ b/src/android/PDFGenerator.java
@@ -73,7 +73,8 @@ public class PDFGenerator extends CordovaPlugin {
                     PrintManager printManager = (PrintManager) cordova.getActivity()
                             .getSystemService(Context.PRINT_SERVICE);
 
-                    PDFPrinterWebView printerWebView = new PDFPrinterWebView(printManager, ctx);
+                    boolean outputBase64 = args.getString(4) != null && args.getString(4).equals("base64");
+                    PDFPrinterWebView printerWebView = new PDFPrinterWebView(printManager, ctx, outputBase64);
 
                     String fileNameArg = args.getString(5);
                     if (fileNameArg != null) {

--- a/src/android/PDFPrinterWebView.java
+++ b/src/android/PDFPrinterWebView.java
@@ -16,7 +16,11 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.LOG;
 
 import java.io.File;
-import java.io.IOException;
+import java.lang.System;
+
+import android.print.PDFtoBase64;
+import android.print.PrintAttributes;
+import android.os.Environment;
 
 /**
  * Created by cesar on 22/01/2017.
@@ -26,16 +30,20 @@ public class PDFPrinterWebView extends WebViewClient {
 
     private PrintManager printManager = null;
     private static final String TAG = "PDFPrinterWebView";
+    private static final String PRINT_JOB_NAME = "PDF_GENERATOR";
+    private static final String PRINT_SUCESS = "sucess";
 
     //Cordova Specific, delete this safely if not using cordova.
     private CallbackContext cordovaCallback;
     private Context ctx;
+    private boolean outputBase64;
 
     private String fileName;
 
-    public PDFPrinterWebView(PrintManager _printerManager, Context ctx){
+    public PDFPrinterWebView(PrintManager _printerManager, Context ctx, Boolean outputBase64){
         printManager = _printerManager;
         this.ctx = ctx;
+        this.outputBase64 = outputBase64;
     }
 
     public void setCordovaCallback(CallbackContext cordovaCallback){
@@ -48,14 +56,20 @@ public class PDFPrinterWebView extends WebViewClient {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
-    public void onPageFinished(WebView view, String url) {
-        super.onPageFinished(view, url);
-
-        PDFPrinter pdfPrinter = new PDFPrinter(view, fileName);
-
-        printManager.print("PDF", pdfPrinter, null);
-
-        this.cordovaCallback.success("success");
+    public void onPageFinished(WebView webView, String url) {
+        super.onPageFinished(webView, url);
+        if(this.outputBase64){
+            PrintAttributes attributes = new PrintAttributes.Builder()
+                .setMediaSize(PrintAttributes.MediaSize.ISO_A4)
+                .setResolution(new PrintAttributes.Resolution("pdf", "pdf", 600, 600))
+                .setMinMargins(PrintAttributes.Margins.NO_MARGINS).build();
+            PDFtoBase64 pdfToBase64 = new PDFtoBase64(attributes, this.ctx, this.cordovaCallback);
+            pdfToBase64.process(webView.createPrintDocumentAdapter(PRINT_JOB_NAME));
+        } else {
+            PDFPrinter pdfPrinter = new PDFPrinter(webView, fileName);
+            printManager.print(PRINT_JOB_NAME, pdfPrinter, null);
+            this.cordovaCallback.success(PRINT_SUCESS);
+        }
     }
 
 }

--- a/src/android/PDFtoBase64.java
+++ b/src/android/PDFtoBase64.java
@@ -1,0 +1,90 @@
+package android.print;
+
+import android.os.CancellationSignal;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+import org.apache.cordova.CallbackContext;
+import android.content.Context;
+import android.util.Base64;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+// https://github.com/cesarvr/pdf-generator/issues/9
+// http://www.annalytics.co.uk/android/pdf/2017/04/06/Save-PDF-From-An-Android-WebView/
+public class PDFtoBase64 {
+
+    private static final String TAG = PDFtoBase64.class.getSimpleName();
+    private static final String FILE_PREFIX = "PDF_GENERATOR";
+    private static final String FILE_EXTENSION = "pdf";
+    private static final String FILE_EMPTY_ERROR = "Error: Empty PDF File";
+    private static final String FILE_NOT_FOUND = "Error: Temp File Not Found";
+    private static final String IO_EXCEPTION = "Error: I/O";
+    private final PrintAttributes printAttributes;
+
+    private Context ctx;
+    private CallbackContext cordovaCallback;
+    private File file;
+    private String encodedBase64;
+
+    public PDFtoBase64(PrintAttributes printAttributes, Context ctx, CallbackContext cordovaCallback) {
+        this.printAttributes = printAttributes;
+        this.ctx = ctx;
+        this.cordovaCallback = cordovaCallback;
+    }
+
+    public void getAsBase64() {
+        try{
+            FileInputStream fileInputStreamReader = new FileInputStream(file);
+            byte[] bytes = new byte[(int)file.length()];
+            fileInputStreamReader.read(bytes);
+            fileInputStreamReader.close();
+            encodedBase64 = Base64.encodeToString( bytes, Base64.DEFAULT );
+            file.delete();
+
+            if(encodedBase64.isEmpty()){
+                cordovaCallback.error(FILE_EMPTY_ERROR);
+            }else{
+                cordovaCallback.success(encodedBase64);
+            }
+        } catch(FileNotFoundException ex) {
+             Log.e(TAG, "getAsBase64 Error File Not Found: ", ex );
+             cordovaCallback.error(FILE_NOT_FOUND);
+        } catch(IOException ex) {
+             Log.e(TAG, "getAsBase64 Error in I/O: ", ex );
+             cordovaCallback.error(IO_EXCEPTION);
+        }
+    }
+
+    public void process(final PrintDocumentAdapter printAdapter) {
+
+        final PrintDocumentAdapter.WriteResultCallback myWriteResultCallback = new PrintDocumentAdapter.WriteResultCallback() {
+            @Override
+            public void onWriteFinished(PageRange[] pages) {
+                super.onWriteFinished(pages);
+                getAsBase64();
+            }
+        };
+
+        final PrintDocumentAdapter.LayoutResultCallback myLayoutResultCallback = new PrintDocumentAdapter.LayoutResultCallback() {
+            @Override
+            public void onLayoutFinished(PrintDocumentInfo info, boolean changed) {
+                printAdapter.onWrite(null, getOutputFile(), new CancellationSignal(), myWriteResultCallback);
+            }
+        };
+
+        printAdapter.onLayout(null, printAttributes, null, myLayoutResultCallback, null);
+    }
+
+    private ParcelFileDescriptor getOutputFile() {
+        try {
+            file = File.createTempFile(FILE_PREFIX, FILE_EXTENSION, ctx.getCacheDir());
+            return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_WRITE);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to open ParcelFileDescriptor", e);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Uses temp file to print direct to file, this is immediately cleaned up once the base64 is read.
The success message receives the Base64 result like in the IOS version.

