### PR TITLE
Fix for setting correct content in page on second print

### DIFF
--- a/src/android/PDFGenerator.java
+++ b/src/android/PDFGenerator.java
@@ -90,7 +90,7 @@ public class PDFGenerator extends CordovaPlugin {
                         webview.loadUrl(args.getString(0));
 
                     if (args.getString(1) != null && !args.getString(1).equals("null"))
-                        webview.loadData(args.getString(1), "text/html; charset=UTF-8", null);
+                        webview.loadDataWithBaseURL(null,args.getString(1), "text/HTML","UTF-8", null);
 
                 } catch (JSONException e) {
                     e.printStackTrace();


### PR DESCRIPTION
This commit fixes a behaviour on Android where printing the same HTML content before and after a small edit resulted in printing the first version both times. It happened mostly on pages with a Base64 Image embedded on top. This appears to solve the problem.

Tested on Samsung Galaxy Tab A - Android 6.0.1