### PR TITLE
bumped package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "cordova-pdf-generator",
-  "version": "2.0.8",
+  "version": "2.2.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-pdf-generator",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "is a HTML to PDF (offline) Generator.",
   "cordova": {
     "id": "cordova-pdf-generator",


### PR DESCRIPTION
The recent fix done for "Fix ios webview url (63843da)" was missing package version bump. 
I was facing the same issue with the plugin and I tested the fixed tag version and it worked.
